### PR TITLE
Remove def{type,interface,protocol}+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clj-commons/byte-streams (or (System/getenv "PROJECT_VERSION") "0.3.4")
+(defproject griffinbank/byte-streams (or (System/getenv "PROJECT_VERSION") "0.3.5-20250811")
   :description "A simple way to handle the menagerie of Java byte representations."
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
@@ -8,8 +8,8 @@
                                     :password :env/clojars_password
                                     :sign-releases false}]]
   :dependencies [[org.clj-commons/primitive-math "1.0.0"]
-                 [manifold/manifold "0.3.0"]
-                 [potemkin "0.4.6"]]
+                 [griffinbank/manifold "0.4.4-20250811"]
+                 [griffinbank/potemkin "0.4.9-20250811"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.1"]
                                   [org.clojure/test.check "1.1.1"]
                                   [rhizome "0.2.9"]

--- a/src/byte_streams/graph.clj
+++ b/src/byte_streams/graph.clj
@@ -8,7 +8,6 @@
   (:require
    [manifold.stream :as s]
    [byte-streams
-    [utils :refer [defprotocol+ defrecord+ deftype+]]
     [protocols :as proto]]
    [clj-commons.primitive-math :as p])
   (:import
@@ -89,7 +88,7 @@
        :else
        (= a b)))))
 
-(defprotocol+ IConversionGraph
+(defprotocol IConversionGraph
   (assoc-conversion [_ src dst f cost])
   (equivalent-targets [_ dst])
   (possible-sources [_])

--- a/src/byte_streams/protocols.clj
+++ b/src/byte_streams/protocols.clj
@@ -4,19 +4,17 @@
    :no-doc true
    :superseded-by "clj-commons.byte-streams.protocols"}
  byte-streams.protocols
-  (:require
-   [byte-streams.utils :refer [defprotocol+]])
   (:import
    [java.util.concurrent
     ConcurrentHashMap]))
 
-(defprotocol+ Closeable
+(defprotocol Closeable
   (close [_] "A protocol that is a superset of `java.io.Closeable`."))
 
-(defprotocol+ ByteSource
+(defprotocol ByteSource
   (take-bytes! [_ n options] "Takes `n` bytes from the byte source."))
 
-(defprotocol+ ByteSink
+(defprotocol ByteSink
   (send-bytes! [_ bytes options] "Puts `bytes` in the byte sink."))
 
 (extend-protocol Closeable

--- a/src/byte_streams/pushback_stream.clj
+++ b/src/byte_streams/pushback_stream.clj
@@ -7,7 +7,7 @@
   (:refer-clojure :exclude [take])
   (:require
    [primitive-math :as p]
-   [byte-streams.utils :refer [doit definterface+ deftype+]]
+   [byte-streams.utils :refer [doit]]
    [manifold
     [utils :as u]
     [stream :as s]
@@ -25,7 +25,7 @@
 
 (set! *unchecked-math* true)
 
-(definterface+ PushbackStream
+(definterface PushbackStream
   (put [^bytes x ^int offset ^int length])
   (put [^java.nio.ByteBuffer buf])
   (pushback [^bytes ary ^int offset ^int length])
@@ -92,7 +92,7 @@
        body)))
 
 (both
- (deftype+ (either [PushbackByteStream] [SynchronizedPushbackByteStream])
+ (deftype (either [PushbackByteStream] [SynchronizedPushbackByteStream])
    [lock
     ^LinkedList consumers
     ^long buffer-capacity

--- a/src/byte_streams/utils.clj
+++ b/src/byte_streams/utils.clj
@@ -5,22 +5,6 @@
    :superseded-by "clj-commons.byte-streams.utils"}
  byte-streams.utils)
 
-(defmacro defprotocol+ [name & body]
-  (when-not (resolve name)
-    `(defprotocol ~name ~@body)))
-
-(defmacro deftype+ [name & body]
-  (when-not (resolve name)
-    `(deftype ~name ~@body)))
-
-(defmacro defrecord+ [name & body]
-  (when-not (resolve name)
-    `(defrecord ~name ~@body)))
-
-(defmacro definterface+ [name & body]
-  (when-not (resolve name)
-    `(definterface ~name ~@body)))
-
 (defmacro doit
   "A version of doseq that doesn't emit all that inline-destroying chunked-seq code."
   [[x it] & body]
@@ -32,4 +16,3 @@
            (let [~x (.next it#)]
              ~@body)
            (recur))))))
-

--- a/src/clj_commons/byte_streams/graph.clj
+++ b/src/clj_commons/byte_streams/graph.clj
@@ -3,7 +3,6 @@
   (:require
    [manifold.stream :as s]
    [clj-commons.byte-streams
-    [utils :refer [defprotocol+ defrecord+ deftype+]]
     [protocols :as proto]]
    [clj-commons.primitive-math :as p])
   (:import
@@ -13,7 +12,7 @@
 
 (declare pprint-type)
 
-(deftype+ Conversion [f ^double cost]
+(deftype Conversion [f ^double cost]
   Object
   (equals [_ x]
           (and
@@ -23,7 +22,7 @@
   (hashCode [_]
             (p/bit-xor (System/identityHashCode f) (unchecked-int cost))))
 
-(deftype+ Type [wrapper type]
+(deftype Type [wrapper type]
   Object
   (equals [_ x]
           (and
@@ -84,7 +83,7 @@
        :else
        (= a b)))))
 
-(defprotocol+ IConversionGraph
+(defprotocol IConversionGraph
   (assoc-conversion [_ src dst f cost])
   (equivalent-targets [_ dst])
   (possible-sources [_])
@@ -110,7 +109,7 @@
     :else
     nil))
 
-(deftype+ ConversionGraph [m]
+(deftype ConversionGraph [m]
   IConversionGraph
   (assoc-conversion [_ src dst f cost]
                     (let [m' (assoc-in m [src dst] (Conversion. f cost))
@@ -156,7 +155,7 @@
 
 ;;;
 
-(defrecord+ ConversionPath [path fns visited? ^double cost]
+(defrecord ConversionPath [path fns visited? ^double cost]
   Comparable
   (compareTo [_ x]
              (let [cmp (compare cost (.cost ^ConversionPath x))]

--- a/src/clj_commons/byte_streams/protocols.clj
+++ b/src/clj_commons/byte_streams/protocols.clj
@@ -1,21 +1,18 @@
 (ns clj-commons.byte-streams.protocols
-  (:require
-   [clj-commons.byte-streams.utils :refer [defprotocol+]])
   (:import
    [java.util.concurrent
     ConcurrentHashMap]))
 
-(defprotocol+ Closeable
+(defprotocol Closeable
   (close [_] "A protocol that is a superset of `java.io.Closeable`."))
 
-(defprotocol+ ByteSource
+(defprotocol ByteSource
   (take-bytes! [_ n options] "Takes `n` bytes from the byte source."))
 
-(defprotocol+ ByteSink
+(defprotocol ByteSink
   (send-bytes! [_ bytes options] "Puts `bytes` in the byte sink."))
 
 (extend-protocol Closeable
-
   java.io.Closeable
   (close [this] (.close this)))
 

--- a/src/clj_commons/byte_streams/pushback_stream.clj
+++ b/src/clj_commons/byte_streams/pushback_stream.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [take])
   (:require
    [clj-commons.primitive-math :as p]
-   [clj-commons.byte-streams.utils :refer [doit definterface+ deftype+]]
+   [clj-commons.byte-streams.utils :refer [doit]]
    [manifold
     [utils :as u]
     [stream :as s]
@@ -20,7 +20,7 @@
 
 (set! *unchecked-math* true)
 
-(definterface+ PushbackStream
+(definterface PushbackStream
   (put [^bytes x ^int offset ^int length])
   (put [^java.nio.ByteBuffer buf])
   (pushback [^bytes ary ^int offset ^int length])
@@ -87,7 +87,7 @@
        body)))
 
 (both
- (deftype+ (either [PushbackByteStream] [SynchronizedPushbackByteStream])
+ (deftype (either [PushbackByteStream] [SynchronizedPushbackByteStream])
    [lock
     ^LinkedList consumers
     ^long buffer-capacity

--- a/src/clj_commons/byte_streams/utils.clj
+++ b/src/clj_commons/byte_streams/utils.clj
@@ -1,21 +1,5 @@
 (ns clj-commons.byte-streams.utils)
 
-(defmacro defprotocol+ [name & body]
-  (when-not (resolve name)
-    `(defprotocol ~name ~@body)))
-
-(defmacro deftype+ [name & body]
-  (when-not (resolve name)
-    `(deftype ~name ~@body)))
-
-(defmacro defrecord+ [name & body]
-  (when-not (resolve name)
-    `(defrecord ~name ~@body)))
-
-(defmacro definterface+ [name & body]
-  (when-not (resolve name)
-    `(definterface ~name ~@body)))
-
 (defmacro doit
   "A version of doseq that doesn't emit all that inline-destroying chunked-seq code."
   [[x it] & body]
@@ -27,4 +11,3 @@
            (let [~x (.next it#)]
              ~@body)
            (recur))))))
-


### PR DESCRIPTION
Remove `deftype+`, `definterface+`, `defprotocol+` from byte-streams, and replace all usage with the built in versions to avoid AOT issues with rules_clojure 